### PR TITLE
Adding appmesh line for CDK package

### DIFF
--- a/content/capacity_providers/software.md
+++ b/content/capacity_providers/software.md
@@ -28,6 +28,7 @@ aws-cdk.aws_iam==$AWS_CDK_VERSION \
 aws-cdk.aws_efs==$AWS_CDK_VERSION \
 aws-cdk.aws_autoscaling==$AWS_CDK_VERSION \
 aws-cdk.aws_ssm==$AWS_CDK_VERSION \
+aws-cdk.aws_appmesh==$AWS_CDK_VERSION \
 awscli \
 awslogs
 


### PR DESCRIPTION
I ran through the commands in the Capacity Providers section and had the following error:
```
  File "app.py", line 4, in <module>
    from aws_cdk import (
ImportError: cannot import name 'aws_appmesh' from 'aws_cdk' (unknown location)
```
Adding `aws_appmesh` so that customers can proceed with the workshop.