### PR TITLE
Adding working node.js version to allow CDK build environment without fail

### DIFF
--- a/content/blue_green_deployments/build_environment.md
+++ b/content/blue_green_deployments/build_environment.md
@@ -11,7 +11,6 @@ sudo yum install -y jq
 npm i -g -f aws-cdk@1.54.0
 nvm install 14.15.4
 nvm use 14.15.4
-
 ```
 
 #### Navigate to the repo


### PR DESCRIPTION
I ran into below issue documented here:

https://github.com/aws-containers/ecsworkshop/issues/18

CREATE_FAILED        | AWS::Lambda::Function                     | createDeploymentGroupLambda
Resource handler returned message: "Uploaded file must be a non-empty zip (Service: Lambda, Status Code: 400, Request ID: 3c34131a-fd1d-4ab8-910c-a5c5835676c1, Extended Request ID: null)" (RequestToken: de7494e8-19
4c-3c7f-0643-eb02c68208b6, HandlerErrorCode: InvalidRequest)

The AWS CDK team is aware and the error is tied to nodejs versions > 15.6

This fix forces nvm to use 14.15.4 which is the version of nodejs that has been confirmed and that i confirmed to work, CDK build proceeds properly when this node version is used