### PR TITLE
Updating running vs tasks desired to come up every 3 seconds

### DIFF
--- a/content/microservices/crystal/tabs/cdk.md
+++ b/content/microservices/crystal/tabs/cdk.md
@@ -305,7 +305,7 @@ siege -c 200 -i http://ecsdemo-crystal.service.local:3000/crystal
 - Compare the tasks running vs tasks desired. As the load increases on the crystal service, we should see these counts eventually increase up to 10. This is autoscaling happening in real time. Please note that this step will take a few minutes. Feel free to run this in one terminal, and move on to the next steps in another terminal.
 
 ```bash
-watch -d -n 3 echo `aws ecs describe-services --cluster container-demo --services ecsdemo-crystal | jq '.services[] | "Tasks Desired: \(.desiredCount) vs Tasks Running: \(.runningCount)"'`
+while true; do sleep 3; aws ecs describe-services --cluster container-demo --services ecsdemo-crystal | jq '.services[] | "Tasks Desired: \(.desiredCount) vs Tasks Running: \(.runningCount)"'; done
 ```
 
 ![task-as-loadtest-output](/images/ecs-cdk-crystal-as-loadtest-output-cli.png)

--- a/content/microservices/nodejs/tabs/cdk.md
+++ b/content/microservices/nodejs/tabs/cdk.md
@@ -303,7 +303,7 @@ siege -c 100 -i http://ecsdemo-nodejs.service.local:3000
 - Compare the tasks running vs tasks desired. As the load increases on the nodejs service, we should see these counts eventually increase up to 10. This is autoscaling happening in real time. Please note that this step will take a few minutes. Feel free to run this in one terminal, and move on to the next steps in another terminal.
 
 ```bash
-watch -d -n 3 echo `aws ecs describe-services --cluster container-demo --services ecsdemo-nodejs | jq '.services[] | "Tasks Desired: \(.desiredCount) vs Tasks Running: \(.runningCount)"'`
+while true; do sleep 3; aws ecs describe-services --cluster container-demo --services ecsdemo-nodejs | jq '.services[] | "Tasks Desired: \(.desiredCount) vs Tasks Running: \(.runningCount)"'; done
 ```
 
 ![task-as-loadtest-output](/images/cdk-task-nodejs-ssm-ec2-autoscale-loadtest-output.png)


### PR DESCRIPTION
Updated command so that running vs tasks desired comes up every 3 seconds in line with the documentation for the CDK tabs in nodejs and crystal.
The previous command didn't update after the fist line.