### PR TITLE
Adding '--include' to 'ecs describe-clusters' cli command

### DIFF
--- a/content/monitoring/container_insights/setup.md
+++ b/content/monitoring/container_insights/setup.md
@@ -35,7 +35,7 @@ aws cloudformation create-stack --stack-name CWAgentECS-$clustername-${AWS_REGIO
 Execute the following command
 
 ```
-aws ecs describe-clusters --cluster ${clustername}
+aws ecs describe-clusters --cluster ${clustername} --include SETTINGS
 ```
 Your output should be similar to the one below. You should see Container Insights being enabled under **settings** section in the JSON.
 


### PR DESCRIPTION
Without adding '--include SETTINGS' to the 'aws ecs describe-clusters --cluster' command the container insights information for the ecs clusters is ommitted. Basically have an empty list [ ] for the 'settings' output portion.

See the below: 
https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-clusters.html

```
"--include (list)

    Whether to include additional information about the clusters in the response. If this field is omitted, this information isn't included."
```

`If SETTINGS is specified, the settings for the cluster are included.`

Deleted my ECS cluster so can't show the output from my tests showing before and after, but valid