### PR TITLE
Replace manual step in Cloud9 setup

### DIFF
--- a/content/start_the_workshop/workspace.md
+++ b/content/start_the_workshop/workspace.md
@@ -56,21 +56,18 @@ in the Cloud9 workspace menu.
 - Choose **ecsworkshop-admin** from the **IAM Role** drop down, and select **Apply**
 ![c9attachrole](/images/c9attachrole.png)
 
-- Return to your workspace and click the gear icon (in top right corner), or click to open a new tab and choose "Open Preferences"
-- Select **AWS SETTINGS**
-- Turn off **AWS managed temporary credentials**
-- Close the Preferences tab
-![c9disableiam](/images/c9disableiam.png)
+- Return to your workspace terminal and perform the next steps
 
 Install jq, as we will use this quite a bit throughout the workshop when interacting with json outputs.
 
 ```sh
 sudo yum install -y jq
 ```
+To ensure temporary credentials aren't already in place we will remove
+any existing credentials file as well as disabling **AWS managed temporary credentials** for Cloud9:
 
-To ensure temporary credentials aren't already in place we will also remove
-any existing credentials file:
 ```sh
+aws cloud9 update-environment  --environment-id $C9_PID --managed-credentials-action DISABLE
 rm -vf ${HOME}/.aws/credentials
 ```
 

--- a/content/start_the_workshop/workspace.md
+++ b/content/start_the_workshop/workspace.md
@@ -63,6 +63,15 @@ Install jq, as we will use this quite a bit throughout the workshop when interac
 ```sh
 sudo yum install -y jq
 ```
+
+Upgrade AWS CLI according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html).
+
+```bash
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+```
+
 To ensure temporary credentials aren't already in place we will remove
 any existing credentials file as well as disabling **AWS managed temporary credentials** for Cloud9:
 


### PR DESCRIPTION
Since Cloud9 CLI support disabling managed-credentials for the workspace from the CLI itself, it can replace the manual process for disabling it via the Cloud9 console.
This is much easier to follow, than doing the manual steps.
Similar to https://github.com/aws-samples/eks-workshop/pull/1296 in EKS workshop