### PR TITLE
Fix the path for nginx-sample in blue_green_deployments

### DIFF
--- a/content/blue_green_deployments/rollback-failed-deployment.md
+++ b/content/blue_green_deployments/rollback-failed-deployment.md
@@ -77,11 +77,11 @@ http {
 
 #### Push the code to the CodeCommit repository
 ```bash
-cd ~/environment/nginx-example
+cd ~/environment/nginx-sample
 git add .
 git commit -m "Returning 500 error"
 git push
-``` 
+```
 
 #### The code push will trigger the CodePipeline
 


### PR DESCRIPTION
In the [Push the code to the CodeCommit repository step](https://ecsworkshop.com/blue_green_deployments/rollback-failed-deployment/#push-the-code-to-the-codecommit-repository) in ROLLBACK FAILED DEPLOYMENT Section, the command for nginx demo path is:

```shell
cd ~/environment/nginx-example
```

It should be `nginx-sample` (see [ecs-workshop-blue-green-deployments repo](https://github.com/aws-containers/ecs-workshop-blue-green-deployments)):

```shell
cd ~/environment/nginx-sample
```