### PR TITLE
Version pin CDK libraries in App Mesh section

### DIFF
--- a/content/networking_sd/app_mesh/gettingstarted/prerequistes.md
+++ b/content/networking_sd/app_mesh/gettingstarted/prerequistes.md
@@ -21,3 +21,9 @@ git clone https://github.com/aws-containers/ecsdemo-frontend
 git clone https://github.com/aws-containers/ecsdemo-nodejs
 git clone https://github.com/aws-containers/ecsdemo-crystal
 ```
+
+Let's pin our CDK libraries to our CLI version
+
+```bash
+for i in ecsdemo-*/cdk/requirements.txt ; do sed -i "s/$/==$AWS_CDK_VERSION/g" $i ; done
+```


### PR DESCRIPTION
Solves #40 by running a single command to version pin the CDK libraries in the `requirements.txt` files of the repos just cloned, so that they match the version of the CLI installed.  That is referenced previously during installation in the `$AWS_CDK_VERSION` environment variable.

Without this fix, the App Mesh section of the workshop does not work as expected.

Upgrading the CLI to the latest version, to match the CDK libraries, does not work.  The `ecsdemo-frontend` CDK probably needs to be reworked to work with later versions of CDK, but this fix will get the App Mesh workshop working again.