### PR TITLE
Missed one repo that was moved

### DIFF
--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -76,18 +76,18 @@
   <h3 class="github-title">Capacity Providers</h3>
   <a
     class="github-button"
-    href="https://github.com/adamjkeller/ecsdemo-capacityproviders"
+    href="https://github.com/aws-containers/ecsdemo-capacityproviders"
     data-icon="octicon-star"
     data-show-count="true"
-    aria-label="Star adamjkeller/ecsdemo-capacityproviders on GitHub"
+    aria-label="Star aws-containers/ecsdemo-capacityproviders on GitHub"
     >Star</a
   >
   &nbsp;<a
     class="github-button"
-    href="https://github.com/adamjkeller/ecsdemo-capacityproviders/fork"
+    href="https://github.com/aws-containers/ecsdemo-capacityproviders/fork"
     data-icon="octicon-repo-forked"
     data-show-count="true"
-    aria-label="Fork adamjkeller/ecsdemo-capacityproviders on GitHub"
+    aria-label="Fork aws-containers/ecsdemo-capacityproviders on GitHub"
     >Fork</a
   >
 


### PR DESCRIPTION
Modifying link to the aws-containers/ecsdemo-capacityproviders which we missed