### PR TITLE
update prerequisites

### DIFF
--- a/content/monitoring/container_insights/software.md
+++ b/content/monitoring/container_insights/software.md
@@ -11,6 +11,7 @@ In the Cloud9 workspace, run the following commands:
 ```
 # Install prerequisite packages
 sudo yum -y install jq gettext
+npm install -g aws-cdk@latest
 ```
 jq is a tool that can be used to extract and transform data held in JSON files.
 


### PR DESCRIPTION
Include latest version of cdk to avoid errors

Without the update the following error is being thrown :- 
This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 17.0.0, but found 18.0.0)