### PR TITLE
Update command for $AMP_WORKSPACE_ID

### DIFF
--- a/content/monitoring/amp_amg/deploy_app.md
+++ b/content/monitoring/amp_amg/deploy_app.md
@@ -22,7 +22,7 @@ In the Cloud9 workspace, run the following commands:
 ```bash
 cd ~/environment/ecsdemo-amp/cdk
 
-export AMP_WORKSPACE_ID=$(aws amp list-workspaces --query 'workspaces[*].workspaceId' --output text)
+export AMP_WORKSPACE_ID=$(aws amp list-workspaces --alias ecs-workshop --query 'workspaces[*].workspaceId' --output text | awk '{print $1;}')
 export AMP_Prometheus_Endpoint=$(aws amp describe-workspace --workspace-id $AMP_WORKSPACE_ID --query 'workspace.prometheusEndpoint' --output text)
 export AMP_Prometheus_Remote_Write_Endpoint='"'${AMP_Prometheus_Endpoint}api/v1/remote_write'"'
 


### PR DESCRIPTION
With the current command, all the workspace IDs are extracted and stored into AMP_WORKSPACE_ID. I had 3 different workspaces which caused the value of AMP_WORKSPACE_ID to be "workspace-1 workspace-2 workspace-3" .
If the AMP_WORKSPACE_ID is not correct then AMP_Prometheus_Endpoint results to be ""  and finally 
AMP_Prometheus_Remote_Write_Endpoint  ends up being "api/v1/remote_write" .

With the above changes, anyone with their own AWS account can freely execute the lab without having to delete all the other workspaces that they have. The updated command checks for the alias. It also ensures that only one string is accepted if the result has more than one entries.