### PR TITLE
update AWS_CDK_VERSION

### DIFF
--- a/content/secrets/01-install-and-configure-tools/cdk.md
+++ b/content/secrets/01-install-and-configure-tools/cdk.md
@@ -11,7 +11,7 @@ hidden: true
 sudo yum -y install nodejs python
 
 # Setting CDK Version
-export AWS_CDK_VERSION="1.95.1"
+export AWS_CDK_VERSION="2.25.0"
 
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION

--- a/content/secrets/01-install-and-configure-tools/cdk.md
+++ b/content/secrets/01-install-and-configure-tools/cdk.md
@@ -11,7 +11,7 @@ hidden: true
 sudo yum -y install nodejs python
 
 # Setting CDK Version
-export AWS_CDK_VERSION="2.25.0"
+export AWS_CDK_VERSION="1.157.0"
 
 # Install aws-cdk
 npm install -g --force aws-cdk@$AWS_CDK_VERSION


### PR DESCRIPTION
version 1.95.1 has 6 vulnerabilities (4 high, 2 critical). 
This is an old version thats not compatible with a lot of other libraries. The lab breaks because of the old version. 

I tried moving to the latest version of cdk : 2.25.0 but then that version is not compatible with the other npm modules that are used in the lab (  aws-cdk.core, aws-cdk.aws_ec2 etc ) 

The version that works well with all the modules is 1.157.0. Thus upgrading to v 1.157.0 for this lab.  