### PR TITLE
Update aws-cdk version from v2 to v1 on container insights chapter

### DIFF
--- a/content/monitoring/container_insights/software.md
+++ b/content/monitoring/container_insights/software.md
@@ -13,7 +13,7 @@ In the Cloud9 workspace, run the following commands:
 sudo yum -y install jq gettext
 
 # Install aws-cdk
-npm install --force -g aws-cdk@2.25.0
+npm install --force -g aws-cdk@1.158.0
 ```
 jq is a tool that can be used to extract and transform data held in JSON files.
 


### PR DESCRIPTION
"Build the platform" section does not seem to work with aws-cdk v2.
https://ecsworkshop.com/monitoring/container_insights/build_environment/#build-the-platform

Below are the output results.

In the case of aws-cdk v2
```sh
hoda:~/environment/ecsdemo-platform/cdk (master) $ cdk context --clear && cdk deploy --require-approval never
All context values cleared.


NOTICES

19836   AWS CDK v1 entering maintenance mode soon

        Overview: AWS CDK v1 is entering maintenance mode on June 1, 2022.
                  Migrate to AWS CDK v2 to continue to get the latest features
                  and fixes!

        Affected versions: framework: 1.*, cli: 1.*

        More information at: https://github.com/aws/aws-cdk/issues/19836


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 19836".
This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 19.0.0, but found 20.0.0)
hoda:~/environment/ecsdemo-platform/cdk (master) $ cdk --version
2.25.0 (build ae1cb4b)
```

In the case of aws-cdk v1.
```sh
hoda:~/environment/ecsdemo-platform/cdk (master) $ npm install --force -g aws-cdk@1.158.0
npm WARN using --force Recommended protections disabled.

changed 1 package, and audited 2 packages in 2s

found 0 vulnerabilities
hoda:~/environment/ecsdemo-platform/cdk (master) $ cdk context --clear && cdk deploy --require-approval never
All context values cleared.

NOTICES

19836   AWS CDK v1 entering maintenance mode soon

        Overview: AWS CDK v1 is entering maintenance mode on June 1, 2022.
                  Migrate to AWS CDK v2 to continue to get the latest features
                  and fixes!

        Affected versions: framework: 1.*, cli: 1.*

        More information at: https://github.com/aws/aws-cdk/issues/19836


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 19836".

✨  Synthesis time: 6.94s

ecsworkshop-base: deploying...
ecsworkshop-base: creating CloudFormation changeset...

 ✅  ecsworkshop-base

✨  Deployment time: 189.08s

Outputs:
ecsworkshop-base.ECSClusterName = container-demo
ecsworkshop-base.ECSClusterSecGrp = []
ecsworkshop-base.FE2BESecGrp = sg-0627998aa98fd0107
ecsworkshop-base.NSArn = arn:aws:servicediscovery:ap-northeast-1:157934765956:namespace/ns-gton5gmadgdu5ivg
ecsworkshop-base.NSId = ns-gton5gmadgdu5ivg
ecsworkshop-base.NSName = service.local
ecsworkshop-base.ServicesSecGrp = sg-0627998aa98fd0107
ecsworkshop-base.StressToolEc2Id = i-09999412eceb4ac93
ecsworkshop-base.StressToolEc2Ip = 10.0.0.120
Stack ARN:
arn:aws:cloudformation:ap-northeast-1:157934765956:stack/ecsworkshop-base/feb21380-de61-11ec-8c31-06ce0e717c1b

✨  Total time: 196.02s


NOTICES

19836   AWS CDK v1 entering maintenance mode soon

        Overview: AWS CDK v1 is entering maintenance mode on June 1, 2022.
                  Migrate to AWS CDK v2 to continue to get the latest features
                  and fixes!

        Affected versions: framework: 1.*, cli: 1.*

        More information at: https://github.com/aws/aws-cdk/issues/19836


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 19836".
hoda:~/environment/ecsdemo-platform/cdk (master) $ cdk --version
1.158.0 (build ab28878)
```