### PR TITLE
fix(blue green) Move npm install AFTER nvm use,

### DIFF
--- a/content/blue_green_deployments/build_environment.md
+++ b/content/blue_green_deployments/build_environment.md
@@ -8,9 +8,9 @@ weight = 3
 
 ```bash
 sudo yum install -y jq
-npm i -g -f aws-cdk@1.128.0
 nvm install 16.10.0
 nvm use 16.10.0
+npm i -g -f aws-cdk@1.128.0
 ```
 
 #### Navigate to the repo


### PR DESCRIPTION
Otherwise cdk command will not be available and return:

```
bash: cdk: command not found
```

See:

```
TeamRole:~/environment $ npm i -g -f aws-cdk@1.128.0
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm WARN using --force Recommended protections disabled.

added 186 packages, and audited 187 packages in 9s

2 vulnerabilities (1 high, 1 critical)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
TeamRole:~/environment $ nvm install 16.10.0
Downloading and installing node v16.10.0...
Downloading https://nodejs.org/dist/v16.10.0/node-v16.10.0-linux-x64.tar.xz...
############################################################################################################################################################################ 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v16.10.0 (npm v7.24.0)
TeamRole:~/environment $ nvm use 16.10.0
Now using node v16.10.0 (npm v7.24.0)
TeamRole:~/environment $ cdk --version
bash: cdk: command not found
TeamRole:~/environment $ npm i -g -f aws-cdk@1.128.0
npm WARN using --force Recommended protections disabled.

added 186 packages, and audited 187 packages in 4s

2 vulnerabilities (1 high, 1 critical)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
TeamRole:~/environment $ cdk --version
1.128.0 (build 1d3883a)
```