### PR TITLE
Corrected a typo in the uncomment script

### DIFF
--- a/content/networking_sd/app_mesh/observability/xray.md
+++ b/content/networking_sd/app_mesh/observability/xray.md
@@ -25,7 +25,7 @@ Now we need to deploy the Xray container sidecar on each service, so the contain
 files=( "ecsdemo-crystal" "ecsdemo-nodejs" "ecsdemo-frontend" "ecsdemo-platform" )
 for i in "${files[@]}"
 do 
-    lines=($(grep -Fn '#ammmesh-xray-uncomment' ~/environment/${i}/cdk/app.py | cut -f1 -d:))
+    lines=($(grep -Fn '#appmesh-xray-uncomment' ~/environment/${i}/cdk/app.py | cut -f1 -d:))
     unstart=$((${lines[0]} + 1))
     unend=$((${lines[1]} - 1))
     sed -i "${unstart},${unend} s/# //" ~/environment/${i}/cdk/app.py 


### PR DESCRIPTION
The comment in the exact code is #appmesh-xray-uncomment, the bash script to uncomment this section in the code had a typo, this is corrected to match the section