### PR TITLE
stop making IAM role assume itself

### DIFF
--- a/content/microservices/tabs/copilot.md
+++ b/content/microservices/tabs/copilot.md
@@ -25,8 +25,6 @@ cat << EOF > ~/.aws/config
 [default]
 region = ${AWS_DEFAULT_REGION}
 output = json
-role_arn = $(aws iam get-role --role-name ecsworkshop-admin | jq -r .Role.Arn)
-credential_source = Ec2InstanceMetadata
 EOF
 
 ```


### PR DESCRIPTION
## Before This PR

An error would occur when one is following [this step](https://ecsworkshop.com/microservices/platform/build_environment/):

```sh
workshop:~/environment $ aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" || aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"

An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::<redacted_account_id>:assumed-role/ecsworkshop-admin/i-<redacted_instance_id> is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::<redacted_account_id>:role/ecsworkshop-admin

An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::<redacted_account_id>:assumed-role/ecsworkshop-admin/i-<redacted_instance_id> is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::<redacted_account_id>:role/ecsworkshop-admin
```

## Why

From this [IAM blog post](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/):

> AWS is changing role assumption behavior to always require self-referential role trust policy grants

This explains why it doesn't work for now. Next question, do we need to add that policy?

> the self-assuming role behavior exhibited by code or human users is very likely to be unnecessary and counterproductive

Since the role is already assumed, it's redundant to assume itself again, so those 2 related lines are removed in this PR.