### PR TITLE
prefix '-n' before app name in 'copilot app show'

### DIFF
--- a/content/microservices/nodejs/tabs/copilot.md
+++ b/content/microservices/nodejs/tabs/copilot.md
@@ -51,7 +51,7 @@ When the deployment is complete, navigate back to the frontend URL and you shoul
 Let's check out the ecsworkshop application details.
 
 ```bash
-copilot app show ecsworkshop
+copilot app show -n ecsworkshop
 ```
 
 The result should look like this:


### PR DESCRIPTION
```sh
workshop:~/environment/ecsdemo-nodejs (main) $ copilot app show --help
Shows configuration, environments and services for an application.

Usage
  copilot app show [flags]

Flags
  -h, --help          help for show
      --json          Optional. Output in JSON format.
  -n, --name string   Name of the application.

Examples
  Shows info about the application "my-app"
  `$ copilot app show -n my-app`
```