### PR TITLE
run 'cdk bootstrap' before running 'cdk deploy'

### DIFF
--- a/content/monitoring/container_insights/build_environment.md
+++ b/content/monitoring/container_insights/build_environment.md
@@ -31,6 +31,12 @@ git clone https://github.com/aws-containers/ecsdemo-nodejs
 git clone https://github.com/aws-containers/ecsdemo-crystal
 ```
 
+#### Bootstrap the CDK environment
+
+```bash
+cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_DEFAULT_REGION
+```
+
 #### Build the platform
 
 First, we need to build the environment for our frontend service to run. For more information on what we're building, you can review the code here: [Platform](../../../microservices/platform/build_environment).


### PR DESCRIPTION
Error message if `cdk bootstrap` is not run before `cdk deploy`:

```sh
 ❌ Building assets failed: Error: Building Assets Failed: Error: ecsworkshop-base: SSM parameter /cdk-bootstrap/hnb659fds/version not found. Has the environment been bootstrapped? Please run 'cdk bootstrap' (see https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html)
```