### PR TITLE
Removing unneeded AWS Config

### DIFF
--- a/content/microservices/tabs/copilot.md
+++ b/content/microservices/tabs/copilot.md
@@ -19,14 +19,4 @@ sudo curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases
 echo "export AWS_DEFAULT_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)" >> ~/.bashrc
 source ~/.bashrc
 
-mkdir -p ~/.aws
-
-cat << EOF > ~/.aws/config
-[default]
-region = ${AWS_DEFAULT_REGION}
-output = json
-role_arn = $(aws iam get-role --role-name ecsworkshop-admin | jq -r .Role.Arn)
-credential_source = Ec2InstanceMetadata
-EOF
-
 ```


### PR DESCRIPTION
AWS Config doesn't need to be here and can cause issues. 

Fixes #64 