### PR TITLE
Code Review section with wrong code

### DIFF
--- a/content/microservices/frontend/tabs/cdk.md
+++ b/content/microservices/frontend/tabs/cdk.md
@@ -225,7 +225,7 @@ cdk deploy
 
 ```python
 # Enable Service Autoscaling
-self.autoscale = fargate_load_balanced_service.service.auto_scale_task_count(
+self.autoscale = self.fargate_load_balanced_service.service.auto_scale_task_count(
    min_capacity=1,
    max_capacity=10
 )
@@ -245,7 +245,7 @@ self.autoscale.scale_on_cpu_utilization(
 
 ```python
 # Enable Service Autoscaling
-self.autoscale = fargate_load_balanced_service.service.auto_scale_task_count(
+self.autoscale = self.fargate_load_balanced_service.service.auto_scale_task_count(
     min_capacity=1,
     max_capacity=10
 )

--- a/content/microservices/frontend/tabs/cdk.md
+++ b/content/microservices/frontend/tabs/cdk.md
@@ -245,8 +245,8 @@ self.autoscale.scale_on_cpu_utilization(
 
 ```python
 # Enable Service Autoscaling
-self.autoscale = self.fargate_service.auto_scale_task_count(
-    min_capacity=3,
+self.autoscale = fargate_load_balanced_service.service.auto_scale_task_count(
+    min_capacity=1,
     max_capacity=10
 )
 ```


### PR DESCRIPTION
In the Code Review paragraph there were pieces of code from the wrong CDK class (FrontendServiceMesh) instead of using the correct ones from the FrontendService class.

*Description of changes:*
I just used the code from FrontendService in order to make the Code Review section consistent with the paragraph before where it is explained how to set the autoscaling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
