### PR TITLE
Fix python installation and update to support IMDSv2

### DIFF
--- a/content/capacity_providers/software.md
+++ b/content/capacity_providers/software.md
@@ -10,10 +10,17 @@ In the Cloud9 workspace, run the following commands:
 
 ```
 # Install prerequisite packages
-sudo yum -y install jq nodejs python36
+sudo yum -y install jq nodejs python3
 
-# Setting environment variables required to communicate with AWS API's via the cli tools
+# Setting environment variables required to communicate with AWS API's via the cli tools, execute either for IMDSv1 or IMDSv2 (based on your IMDS version)
+# IMDSv1
 echo "export AWS_DEFAULT_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)" >> ~/.bashrc
+echo "export AWS_REGION=\$AWS_DEFAULT_REGION" >> ~/.bashrc
+echo "export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> ~/.bashrc
+source ~/.bashrc
+
+# IMDSv2
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) && echo "AWS_DEFAULT_REGION=$REGION" >> ~/.bashrc
 echo "export AWS_REGION=\$AWS_DEFAULT_REGION" >> ~/.bashrc
 echo "export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> ~/.bashrc
 source ~/.bashrc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Fix python installation and update to support IMDSv2

- Executing the command `sudo yum -y install jq nodejs python36` gives below error
`No match for argument: python36
Error: Unable to find a match: python36`

- This command `echo "export AWS_DEFAULT_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)" >> ~/.bashrc` is not supported in EC2 instance types with IMDS version2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
